### PR TITLE
Implement option to opt out of console report

### DIFF
--- a/csv-to-json/README.md
+++ b/csv-to-json/README.md
@@ -22,8 +22,11 @@ csv.write('path/to/file'); // Console reads “Parsed Items: #”
 
 ---
 
-By default, a report is sent to the console (“Parsed Items: #” for `.parse()`; “File saved” for `.write()`). You can pass a second argument `false` to bypass this behavior. Like so:
+By default, a report is sent to the console (“Parsed Items: #” for `.parse()`; “File saved” for `.write()`). You can pass an config object as a second argument with `console: false` to bypass this behavior. Like so:
 ```javascript
-var json = csv.parse('path/to/file', false);
-csv.write('path/to/file', false);
+var config = {
+    console: false
+}
+var json = csv.parse('path/to/file', config);
+csv.write('path/to/file', config);
 ```

--- a/csv-to-json/csv.js
+++ b/csv-to-json/csv.js
@@ -1,9 +1,9 @@
 var fs = require('fs');
 
-exports.parse = function(filename, reportToConsole) {
+exports.parse = function(filename, config) {
 	var csv = fs.readFileSync(filename).toString().split("\n");
 	var json = [];
-	reportToConsole = typeof(reportToConsole) !== 'undefined' ? reportToConsole : true;
+	config.console = typeof(config.console) !== 'undefined' ? config.console : true;
 
 	var tokens = csv[0].split(",");
 
@@ -20,7 +20,7 @@ exports.parse = function(filename, reportToConsole) {
 		json.push(tmp);
 	}
 
-	if (reportToConsole) {
+	if (config.console) {
 		console.log("Parsed Items: "+json.length);
 	}
 
@@ -28,14 +28,14 @@ exports.parse = function(filename, reportToConsole) {
 	return json;
 }
 
-exports.write = function(filename, reportToConsole) {
+exports.write = function(filename, config) {
 	var json = this.json;
-	reportToConsole = typeof(reportToConsole) !== 'undefined' ? reportToConsole : true;
+	config.console = typeof(config.console) !== 'undefined' ? config.console : true;
 
 	fs.writeFile(filename, JSON.stringify(json), function(err) {
 		if (err) {
 			console.log(err);
-		} else if (reportToConsole) {
+		} else if (config.console) {
 			console.log("File saved");
 		}
 	});


### PR DESCRIPTION
By default, a report is sent to the console (“Parsed Items: #” for `.parse()`; “File saved” for `.write()`). You can pass a second argument `false` to bypass this behavior. Like so:

``` javascript
var json = csv.parse('path/to/file', false);
csv.write('path/to/file', false);
```

This patch doesn’t break expected behavior. If no second argument is passed, module behaves as before (reports to the console as usual).
