### PR TITLE
Fixes the split method to handle Unix and Windows new lines

### DIFF
--- a/csv-to-json/lib/csv.js
+++ b/csv-to-json/lib/csv.js
@@ -13,7 +13,7 @@ module.exports = {
             if (err) {
                 return next(err);
             }
-            var csv = data.toString().split("\n");
+            var csv = data.toString().split(/\r\n|\n|\r/);
             var tokens = csv[0].split(",");
             for(var i=1;i < csv.length;i++) {
                 var content = csv[i].split(",");


### PR DESCRIPTION
I was using this module and I realized that the parse function fails when you don't account for carriage returns. I modified the split function on line 16 to remedy this. All of the tests still pass.